### PR TITLE
Allowing multiple accounts to be set in the SQLSYSADMINACCOUNTS parameter when installing sql server

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.getchef.com"
+
+metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,15 @@
+DEPENDENCIES
+  sql_server
+    path: .
+    metadata: true
+
+GRAPH
+  chef-sugar (3.1.0)
+  chef_handler (1.1.6)
+  openssl (4.0.0)
+    chef-sugar (>= 0.0.0)
+  sql_server (2.2.3)
+    openssl (>= 0.0.0)
+    windows (>= 1.2.6)
+  windows (1.36.6)
+    chef_handler (>= 0.0.0)

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -31,7 +31,7 @@ default['sql_server']['rs_mode'] = 'FilesOnlyMode'
 default['sql_server']['rs_account'] = 'NT AUTHORITY\NETWORK SERVICE'
 default['sql_server']['rs_startup'] = 'Automatic'
 default['sql_server']['browser_startup'] = 'Disabled'
-default['sql_server']['sysadmins'] = 'Administrator'
+default['sql_server']['sysadmins'] = ['Administrator']
 default['sql_server']['sql_account'] = 'NT AUTHORITY\NETWORK SERVICE'
 
 default['sql_server']['server']['installer_timeout'] = 1500

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -34,9 +34,13 @@ node.set_unless['sql_server']['server_sa_password'] = "#{secure_password}-aA12"
 node.save unless Chef::Config[:solo]
 
 config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], "ConfigurationFile.ini"))
+sql_sys_admin_list = "#{node['sql_server']['sysadmins'].join(" ")}"
 
 template config_file_path do
   source "ConfigurationFile.ini.erb"
+  variables(
+    sqlSysAdminList: sql_sys_admin_list
+  )
 end
 
 windows_package node['sql_server']['server']['package_name'] do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -35,10 +35,10 @@ node.save unless Chef::Config[:solo]
 
 config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], "ConfigurationFile.ini"))
 
-if node['sql_server']['sysadmins'].is_a? String
-  sql_sys_admin_list = "#{node['sql_server']['sysadmins'].join(" ")}"
-else
+if node['sql_server']['sysadmins'].is_a? Array
   sql_sys_admin_list = node['sql_server']['sysadmins']
+else  
+  sql_sys_admin_list = node['sql_server']['sysadmins'].join(' ')
 end
 
 template config_file_path do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -34,7 +34,12 @@ node.set_unless['sql_server']['server_sa_password'] = "#{secure_password}-aA12"
 node.save unless Chef::Config[:solo]
 
 config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], "ConfigurationFile.ini"))
-sql_sys_admin_list = "#{node['sql_server']['sysadmins'].join(" ")}"
+
+if node['sql_server']['sysadmins'].is_a? String
+  sql_sys_admin_list = "#{node['sql_server']['sysadmins'].join(" ")}"
+else
+  sql_sys_admin_list = node['sql_server']['sysadmins']
+end
 
 template config_file_path do
   source "ConfigurationFile.ini.erb"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -33,16 +33,16 @@ node.set_unless['sql_server']['server_sa_password'] = "#{secure_password}-aA12"
 # force a save so we don't lose our generated password on a failed chef run
 node.save unless Chef::Config[:solo]
 
-config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], "ConfigurationFile.ini"))
+config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini'))
 
 if node['sql_server']['sysadmins'].is_a? Array
-  sql_sys_admin_list = node['sql_server']['sysadmins']
-else  
   sql_sys_admin_list = node['sql_server']['sysadmins'].join(' ')
+else  
+  sql_sys_admin_list = node['sql_server']['sysadmins']
 end
 
 template config_file_path do
-  source "ConfigurationFile.ini.erb"
+  source 'ConfigurationFile.ini.erb'
   variables(
     sqlSysAdminList: sql_sys_admin_list
   )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+at_exit { ChefSpec::Coverage.report! }

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -59,7 +59,7 @@ describe 'sql_server::server' do
 
     it 'creates the correct ConfigurationFile.ini template' do
       expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
-      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^"SQLSYSADMINACCOUNTS=Administrator"$/)
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator"$/)
     end
 
 

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -1,0 +1,71 @@
+#
+# Cookbook Name:: sql_server
+# Spec:: server
+#
+# Copyright (c) 2015 Irving Popovetsky, All Rights Reserved.
+
+require 'spec_helper'
+
+describe 'sql_server::server' do
+
+  context 'When all attributes are default, on Windows 2008R2, it should converge successfully' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'When all attributes are default, on Windows 2012, it should converge successfully' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'When specifying an Array of admin users for "sysadmins"' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012', file_cache_path: 'C:\chef\cache') do |node|
+        node.set['sql_server']['sysadmins'] = ['Administrator', 'Fred', 'Barney']
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'creates the correct ConfigurationFile.ini template' do
+      expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator Fred Barney"$/)
+    end
+
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+  context 'When specifying a String for "sysadmins"' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'windows', version: '2012', file_cache_path: 'C:\chef\cache') do |node|
+        node.set['sql_server']['sysadmins'] = 'Administrator'
+      end
+      runner.converge(described_recipe)
+    end
+
+    it 'creates the correct ConfigurationFile.ini template' do
+      expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^"SQLSYSADMINACCOUNTS=Administrator"$/)
+    end
+
+
+    it 'converges successfully' do
+      chef_run # This should not raise an error
+    end
+  end
+
+end

--- a/templates/default/ConfigurationFile.ini.erb
+++ b/templates/default/ConfigurationFile.ini.erb
@@ -165,7 +165,7 @@ SQLSVCACCOUNT="<%= node['sql_server']['sql_account'] %>"
 ; Windows account(s) to provision as SQL Server system administrators.
 
 ;SQLSYSADMINACCOUNTS="IP-0A7A5B97\Administrator"
-SQLSYSADMINACCOUNTS="<%= node['sql_server']['sysadmins'] %>"
+SQLSYSADMINACCOUNTS=<%= @sqlSysAdminList %>
 
 ; Provision current user as a Database Engine system administrator for SQL Server 2008 R2 Express.
 

--- a/templates/default/ConfigurationFile.ini.erb
+++ b/templates/default/ConfigurationFile.ini.erb
@@ -165,11 +165,11 @@ SQLSVCACCOUNT="<%= node['sql_server']['sql_account'] %>"
 ; Windows account(s) to provision as SQL Server system administrators.
 
 ;SQLSYSADMINACCOUNTS="IP-0A7A5B97\Administrator"
-SQLSYSADMINACCOUNTS=<%= @sqlSysAdminList %>
+SQLSYSADMINACCOUNTS="<%= @sqlSysAdminList %>"
 
 ; Provision current user as a Database Engine system administrator for SQL Server 2008 R2 Express.
 
-ADDCURRENTUSERASSQLADMIN="<%= node['sql_server']['instance_name'] == 'SQLEXPRESS' ? "True" : "False" %>"
+ADDCURRENTUSERASSQLADMIN="<%= node['sql_server']['instance_name'] == 'SQLEXPRESS' ? 'True' : 'False' %>"
 
 ; Specify 0 to disable or 1 to enable the TCP/IP protocol.
 


### PR DESCRIPTION
Fixed issue where you could not submit multiple accounts to the SQLSYSADMINACCOUNTS parameter when installing sql server